### PR TITLE
Java8: Update the broken links and commands

### DIFF
--- a/ubuntu/jdk/Dockerfile
+++ b/ubuntu/jdk/Dockerfile
@@ -1,9 +1,11 @@
-FROM ubuntu:latest
+FROM ubuntu:focal-20241011
 MAINTAINER SgrAlpha <admin@mail.sgr.io>
 
 ENV DEBIAN_FRONTEND=noninteractive \
     JAVA_HOME=/usr/lib/jvm/java-8-oracle \
     JRE_HOME=/usr/lib/jvm/java-8-oracle/jre
+
+COPY jdk8.tar.gz /
 
 RUN VERSION=8 && \
     UPDATE=202 && \
@@ -11,10 +13,7 @@ RUN VERSION=8 && \
     SIG=1961070e4c9b4e26a04e7f5a083f551e && \
     apt-get update && apt-get dist-upgrade -y && \
     apt-get install apt-utils ca-certificates curl -y --no-install-recommends && \
-    curl --silent --location --retry 3 --cacert /etc/ssl/certs/GeoTrust_Global_CA.pem \
-        --header "Cookie: oraclelicense=accept-securebackup-cookie;" \
-        http://download.oracle.com/otn-pub/java/jdk/"${VERSION}"u"${UPDATE}"-b"${BUILD}"/"${SIG}"/jdk-"${VERSION}"u"${UPDATE}"-linux-x64.tar.gz \
-        | tar xz -C /tmp && \
+    tar -xz -C /tmp -f jdk8.tar.gz && \
     mkdir -p /usr/lib/jvm && mv /tmp/jdk1.${VERSION}.0_${UPDATE} "${JAVA_HOME}" && \
     apt-get autoclean && apt-get --purge -y autoremove && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \

--- a/ubuntu/jdk/README.md
+++ b/ubuntu/jdk/README.md
@@ -69,5 +69,10 @@ The following tags are archived:
 * Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files
   * This is enabled by defualt in Java 9, and Java 8 updates later than 162.
 
-
+## Update the Dockerfile
+Changed the Dockerfile because of the broken link and command.
+1. "FROM ubuntu:lastest" -> "From ubuntu:focal-20241011"
+2. add "COPY jdk8.tar.gz /" and you should get your jdk tar gz from the official ORACLE Page (https://www.oracle.com/kr/java/technologies/javase/javase8-archive-downloads.html).
+3. delete "curl ...GeoTrust_Global_CA.pem ... http://download.oracle.com/"-linux-x64.tar.gz \" which is not available anymore.
+4. fix "tar xz -C /tmp" with "tar -xz -C /tmp -f jdk8.tar.gz" because you need to specify the file.
 


### PR DESCRIPTION
When I tried to build the docker image of jdk8 from this, I found it a bit old and it includes some broken stuff like link or command. And I seek about for a new link like mirror or other substitute but I couldn't.
Finally, I made it up and actually I got the jdk8 for linux.tar.gz file for myself from the official ORACLE page since the curl link has been broken.

Here's what I changed:
1. "FROM ubuntu:lastest" -> "From ubuntu:focal-20241011" (from https://hub.docker.com/_/ubuntu/tags?name=focal)
2. add "COPY jdk8.tar.gz /" and you should get your jdk tar gz from the official ORACLE Page (https://www.oracle.com/kr/java/technologies/javase/javase8-archive-downloads.html).
3. delete "curl ...GeoTrust_Global_CA.pem ... http://download.oracle.com/"-linux-x64.tar.gz \" which is not available anymore.
4. fix "tar xz -C /tmp" with "tar -xz -C /tmp -f jdk8.tar.gz" because you need to specify the file.

If you are still interesting in this traditional system, please read this and consider my log.